### PR TITLE
Fix: Handle variable names with spaces (GH #151)

### DIFF
--- a/R/add_core_info_to_chapter_structure.R
+++ b/R/add_core_info_to_chapter_structure.R
@@ -1,48 +1,89 @@
 add_core_info_to_chapter_structure <-
   function(chapter_structure) {
-
     col_headers <- c("dep", "indep")
-    delim_regex <- "[,[:space:]]+"
-    attr(delim_regex, "options") <-
-      list(case_insensitive = FALSE,
-           comments = FALSE,
-           dotall = FALSE,
-           multiline = FALSE)
-    class(delim_regex) <- c("stringr_regex", "stringr_pattern", "character")
 
     out <-
       tidyr::pivot_longer(chapter_structure,
-                          cols = tidyselect::any_of(col_headers),
-                          values_to = ".variable_selection")
+        cols = tidyselect::any_of(col_headers),
+        values_to = ".variable_selection"
+      )
     out <-
-      vctrs::vec_slice(out,
-                       !(out$name == "indep" &
-                           (is.na(out$.variable_selection) |
-                              out$.variable_selection == "")))
+      vctrs::vec_slice(
+        out,
+        !(out$name == "indep" &
+          (is.na(out$.variable_selection) |
+            out$.variable_selection == ""))
+      )
+
+    # Split .variable_selection but preserve spaces within backtick-quoted names
+    # First, normalize the delimiters outside of backticks
+    out$.variable_selection <- vapply(
+      out$.variable_selection,
+      function(str) {
+        if (is.na(str) || str == "") {
+          return(str)
+        }
+
+        # Find all backtick-quoted variable names
+        backtick_pattern <- "`[^`]+`"
+        matches <- stringi::stri_extract_all_regex(str, backtick_pattern)[[1]]
+
+        if (all(is.na(matches))) {
+          # No backtick-quoted names, process normally
+          stringi::stri_replace_all_regex(str, "[,[:space:]]+", ",")
+        } else {
+          # Replace backtick sections with placeholders, process, then restore
+          placeholders <- paste0("__BQUOTE_", seq_along(matches), "__")
+          temp_str <- str
+          for (i in seq_along(matches)) {
+            temp_str <- stringi::stri_replace_first_fixed(temp_str, matches[i], placeholders[i])
+          }
+          # Now replace spaces/commas in the non-backtick parts
+          temp_str <- stringi::stri_replace_all_regex(temp_str, "[,[:space:]]+", ",")
+          # Restore backtick-quoted names
+          for (i in seq_along(matches)) {
+            temp_str <- stringi::stri_replace_first_fixed(temp_str, placeholders[i], matches[i])
+          }
+          temp_str
+        }
+      },
+      character(1),
+      USE.NAMES = FALSE
+    )
+
+    # Now split by comma (which won't be inside backticks after our processing)
     out <-
       tidyr::separate_longer_delim(out,
-                                   cols = ".variable_selection",
-                                   delim = delim_regex)
+        cols = ".variable_selection",
+        delim = ","
+      )
     out <-
       tidyr::separate(out,
-                      col = .data$name,
-                      into = ".variable_role",
-                      sep="_")
+        col = .data$name,
+        into = ".variable_role",
+        sep = "_"
+      )
 
     out[[".variable_role"]] <-
       ifelse(is.na(out[[".variable_selection"]]) |
-               out[[".variable_selection"]] == "", NA_character_, out[[".variable_role"]])
+        out[[".variable_selection"]] == "", NA_character_, out[[".variable_role"]])
 
     out[[".variable_selection"]] <-
-      dplyr::if_else(!stringi::stri_detect(out$.variable_selection,
-                                           regex = "matches\\(") &
-                       stringi::stri_detect(out$.variable_selection,
-                                            regex = "\\*"),
-                     true = stringi::stri_c(ignore_null=TRUE,
-                                            "matches('",
-                                            out$.variable_selection,
-                                            "')"),
-                     false = out$.variable_selection)
+      dplyr::if_else(
+        !stringi::stri_detect(out$.variable_selection,
+          regex = "matches\\("
+        ) &
+          stringi::stri_detect(out$.variable_selection,
+            regex = "\\*"
+          ),
+        true = stringi::stri_c(
+          ignore_null = TRUE,
+          "matches('",
+          out$.variable_selection,
+          "')"
+        ),
+        false = out$.variable_selection
+      )
     out <-
       dplyr::distinct(out, .keep_all = TRUE)
     out <-

--- a/R/add_parsed_vars_to_chapter_structure.R
+++ b/R/add_parsed_vars_to_chapter_structure.R
@@ -1,15 +1,11 @@
 add_parsed_vars_to_chapter_structure <-
   function(chapter_structure,
-           data) {
+           data,
+           call = rlang::caller_env()) {
     chapter_structure$.variable_selection <-
       stringi::stri_replace_all_fixed(chapter_structure$.variable_selection,
         pattern = '\"',
         replacement = "'"
-      )
-    chapter_structure$.variable_selection <-
-      stringi::stri_replace_all_regex(chapter_structure$.variable_selection,
-        pattern = "[[:space:],]+",
-        replacement = ","
       )
 
     chapter_structure$.cols <-


### PR DESCRIPTION
## Summary

Fixes issue where 
refine_chapter_overview() fails when variable names contain spaces.

## Problem

When users specify backtick-quoted variable names with spaces in chapter_overview or chapter_overview (e.g., ` \var with space\ `), the function was incorrectly splitting these names at the spaces, causing errors.

## Root Cause

The delimiter regex pattern \[,[:space:]]+\ in \dd_core_info_to_chapter_structure()\ was being applied indiscriminately, splitting variable names even when they were within backtick quotes.

## Solution

Implemented a placeholder replacement strategy:
1. Extract all backtick-quoted variable names
2. Temporarily replace them with placeholders
3. Apply the delimiter regex to normalize spaces/commas
4. Restore the original backtick-quoted names

This ensures spaces within backtick-quoted names are preserved while still normalizing delimiters elsewhere.

## Testing

- All 549 tests pass
- New test verifies:
  - Backtick-quoted variable names with spaces are correctly parsed
  - Mixed input (backtick-quoted and normal names) works correctly
  - Variable names are extracted without backticks after processing

## Example

\\\
test_data <- data.frame(
  `var with space` = factor(c('A', 'B', 'C')),
  normal_var = c(1, 2, 3),
  check.names = FALSE
)

ch_overview <- data.frame(
  chapter = 'Test',
  dep = '`var with space`, normal_var'
)

result <- refine_chapter_overview(
  chapter_overview = ch_overview,
  data = test_data
)

## Closes

- Closes #151