### PR TITLE
fix: robust error handling in read_main_password_file (GH #90)

### DIFF
--- a/R/read_main_password_file.R
+++ b/R/read_main_password_file.R
@@ -1,6 +1,22 @@
-
 read_main_password_file <- function(file) {
-  utils::read.table(file = file, header = TRUE,
-                    sep=":")
+  # Check if file exists
+  if (!file.exists(file)) {
+    cli::cli_abort("Password file '{.file {file}}' does not exist.")
+  }
+  # Check if file is readable and non-empty
+  if (file.info(file)$size == 0) {
+    cli::cli_abort("Password file '{.file {file}}' is empty.")
+  }
+  # Try reading the file
+  result <- tryCatch(
+    utils::read.table(file = file, header = TRUE, sep = ":", stringsAsFactors = FALSE),
+    error = function(e) {
+      cli::cli_abort("Password file '{.file {file}}' is incorrectly formatted: {e$message}")
+    }
+  )
+  # Check for at least two columns
+  if (ncol(result) < 2) {
+    cli::cli_abort("Password file '{.file {file}}' is incorrectly formatted: must have at least two columns separated by ':'")
+  }
+  result
 }
-

--- a/tests/testthat/test-read_main_password_file.R
+++ b/tests/testthat/test-read_main_password_file.R
@@ -1,0 +1,35 @@
+test_that("read_main_password_file fails with informative error on missing file", {
+  expect_error(
+    read_main_password_file("nonexistent_file.txt"),
+    "does not exist"
+  )
+})
+
+test_that("read_main_password_file fails with informative error on empty file", {
+  tmp <- tempfile()
+  file.create(tmp)
+  expect_error(
+    read_main_password_file(tmp),
+    "is empty"
+  )
+  unlink(tmp)
+})
+
+test_that("read_main_password_file fails with informative error on bad format", {
+  tmp <- tempfile()
+  writeLines(c("not:enough", "onlyonecolumn"), tmp)
+  expect_error(
+    read_main_password_file(tmp),
+    "incorrectly formatted"
+  )
+  unlink(tmp)
+})
+
+test_that("read_main_password_file works with correct format", {
+  tmp <- tempfile()
+  writeLines(c("username:password"), tmp)
+  df <- read_main_password_file(tmp)
+  expect_true(is.data.frame(df))
+  expect_equal(ncol(df), 2)
+  unlink(tmp)
+})


### PR DESCRIPTION
## Summary
This PR makes ead_main_password_file() robust and user-friendly:
- Uses cli::cli_abort() for all error messages
- Fails with clear errors for missing, empty, or incorrectly formatted password files
- Adds comprehensive tests for error handling and valid input
- Addresses GH issue #90

All tests pass. Ready for review and merge.