### PR TITLE
Add interactive HTML plot templates

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -115,6 +115,49 @@ _{.variable_label_prefix_dep}_. `{{r}} x`.
 "
     ) |>
     tibble::add_row(
+      .template_name = "int_plot_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = "fct;ord",
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+{.obj_name} <- \n\tdata_{.chapter_foldername} |>\n\t\tmakeme(dep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype = 'int_plot_html')
+link <- make_link(data = {.obj_name}$data)
+link_plot <- make_link(data = {.obj_name}, \n\t\tfile_suffix = '.png', link_prefix='[PNG](', \n\t\tsave_fn = ggsaver)
+x <- I(paste0(c(link, link_plot), collapse=', '))
+girafe(ggobj = {.obj_name})
+```
+
+_{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_. `{{r}} x`.
+
+:::
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "int_table_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+```{{r}}
+{.obj_name} <- \n\tdata_{.chapter_foldername} |>\n\t\tmakeme(dep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype = 'int_plot_html')
+link <- make_link(data = {.obj_name}$data)
+link_plot <- make_link(data = {.obj_name}, \n\t\tfile_suffix = '.png', link_prefix='[PNG](', \n\t\tsave_fn = ggsaver)
+x <- I(paste0(c(link, link_plot), collapse=', '))
+girafe(ggobj = {.obj_name})
+```
+
+_{.variable_label_prefix_dep}_. `{{r}} x`.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
       .template_name = "cat_table_html",
       .template_variable_type_dep = "fct;ord",
       .template_variable_type_indep = "fct;ord",
@@ -228,7 +271,7 @@ if(!all(vapply(plots, is.null, logical(1)))) {{
   lapply(names(plots), function(.x) {{
     knitr::knit_child(text = c(
       '',
-      '\\newpage',
+      '#\\newpage',
       '',
       '##### `r .x`',
       '```{{r}}',
@@ -278,7 +321,7 @@ if(!all(vapply(plots, is.null, logical(1)))) {{
   lapply(names(plots), function(.x) {{
     knitr::knit_child(text = c(
       '',
-      '\\newpage',
+      '#\\newpage',
       '',
       '##### `r .x`',
       '',
@@ -312,6 +355,96 @@ _{.variable_label_prefix_dep}_.
 "
     ) |>
     tibble::add_row(
+      .template_name = "int_plot_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = "fct;ord",
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype='int_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+
+if(!all(vapply(plots, is.null, logical(1)))) {{
+
+  lapply(names(plots), function(.x) {{
+    knitr::knit_child(text = c(
+      '',
+      '#\\newpage',
+      '',
+      '##### `r .x`',
+      '',
+      '```{{r}}',
+      'library(ggplot2)',
+      'library(ggiraph)',
+      'link <- make_link(data = plots[[.x]]$data)',
+      'link_plot <- make_link(data = plots[[.x]], link_prefix=\\'[PNG](\\', file_suffix = \\'.png\\', save_fn = ggsaver)',
+      'x <- I(paste0(c(link, link_plot), collapse=\\', \\'))',
+      'girafe(ggobj = plots[[.x]])',
+      '```',
+      '',
+      '`r x`',
+      ''
+      ), envir = environment(), quiet = TRUE)
+  }}) |> unlist() |> cat(sep = '\\n')
+}}
+```
+
+_{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "int_plot_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\ttype='int_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+
+if(!all(vapply(plots, is.null, logical(1)))) {{
+
+  lapply(names(plots), function(.x) {{
+    knitr::knit_child(text = c(
+      '',
+      '#\\newpage',
+      '',
+      '##### `r .x`',
+      '',
+      '```{{r}}',
+      'library(ggplot2)',
+      'library(ggiraph)',
+      'link <- make_link(data = plots[[.x]]$data)',
+      'link_plot <- make_link(data = plots[[.x]], link_prefix=\\'[PNG](\\', file_suffix = \\'.png\\', save_fn = ggsaver)',
+      'x <- I(paste0(c(link, link_plot), collapse=\\', \\'))',
+      'girafe(ggobj = plots[[.x]])',
+      '```',
+      '',
+      '`r x`',
+      ''
+      ), envir = environment(), quiet = TRUE)
+  }}) |> unlist() |> cat(sep = '\\n')
+}}
+```
+
+_{.variable_label_prefix_dep}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
       .template_name = "cat_table_html",
       .template_variable_type_dep = "fct;ord",
       .template_variable_type_indep = "fct;ord",
@@ -328,7 +461,7 @@ if(!all(vapply(tbls, is.null, logical(1)))) {{
 lapply(names(tbls), function(.x) {{
   knitr::knit_child(text = c(
       '',
-      '\\newpage',
+      '#\\newpage',
       '',
     '##### `r .x`',
     '',
@@ -372,7 +505,7 @@ if(!all(vapply(tbls, is.null, logical(1)))) {{
 lapply(names(tbls), function(.x) {{
   knitr::knit_child(text = c(
       '',
-      '\\newpage',
+      '#\\newpage',
       '',
     '##### `r .x`',
     '',

--- a/tests/testthat/test-refine_chapter_overview.R
+++ b/tests/testthat/test-refine_chapter_overview.R
@@ -124,7 +124,7 @@ testthat::test_that("refine_chapter_overview", {
       label_separator = " - ",
       name_separator = "_"
     )
-  testthat::expect_equal(dim(x), c(1 + 1 + 7 * 4 + 7 * 4 + 8 * 2, 48))
+  testthat::expect_equal(dim(x), c(1 + 1 + 7 * 4 + 7 * 4 + 2 * 2 + 8 * 2, 48))
 })
 
 testthat::test_that("refine_chapter_overview with always_show_bi_for_indep keeps specified bivariates", {

--- a/tests/testthat/test-remove_from_chapter_structure_if_no_overlap.R
+++ b/tests/testthat/test-remove_from_chapter_structure_if_no_overlap.R
@@ -79,8 +79,8 @@ testthat::test_that("remove_from_chapter_structure_if_no_overlap handles single-
 testthat::test_that("keep_dep_indep_if_no_overlap works in refine_chapter_overview", {
     # Create test data
     test_data <- data.frame(
-        var1 = c(1, NA, 3),
-        var2 = c(NA, 2, NA)
+        var1 = factor(c(1, NA, 3)),
+        var2 = factor(c(NA, 2, NA))
     )
     attr(test_data[["var1"]], "label") <- "Variable 1"
     attr(test_data[["var2"]], "label") <- "Variable 2"
@@ -95,12 +95,14 @@ testthat::test_that("keep_dep_indep_if_no_overlap works in refine_chapter_overvi
     result_keep <- saros.base::refine_chapter_overview(
         chapter_overview = test_overview,
         data = test_data,
+        hide_chunk_if_n_below = 0,
         keep_dep_indep_if_no_overlap = TRUE
     )
 
     # Test with keep_dep_indep_if_no_overlap = FALSE (default)
     result_remove <- saros.base::refine_chapter_overview(
         chapter_overview = test_overview,
+        hide_chunk_if_n_below = 0,
         data = test_data
     )
 


### PR DESCRIPTION
This PR adds support for interactive HTML plots and tables:

- Adds \int_plot_html\ templates for both univariate and bivariate cases
- Adds \int_table_html\ template for univariate case  
- Comments out \\newpage\ in templates to improve HTML rendering
- Updates test expectations to account for new templates
- Fixes test data types to use factors in overlap tests

The new templates support:
- Interactive plots using ggiraph
- Download links for data and PNG exports
- Tabset panels for mesos groups
- Proper figure captions and labels