### PR TITLE
Fix int_table_html template parameter

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -143,7 +143,7 @@ _{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_. `{{
       .template =
         "
 ```{{r}}
-{.obj_name} <- \n\tdata_{.chapter_foldername} |>\n\t\tmakeme(dep = c({.variable_name_dep}), \n\t\ttype = 'int_plot_html')
+{.obj_name} <- \n\tdata_{.chapter_foldername} |>\n\t\tmakeme(dep = c({.variable_name_dep}), \n\t\ttype = 'int_table_html')
 link <- make_link(data = {.obj_name}$data)
 link_plot <- make_link(data = {.obj_name}, \n\t\tfile_suffix = '.png', link_prefix='[PNG](', \n\t\tsave_fn = ggsaver)
 x <- I(paste0(c(link, link_plot), collapse=', '))


### PR DESCRIPTION
Fixes the \int_table_html\ univariate template by removing the incorrect \indep\ parameter.

## Changes
- Remove \indep\ parameter from \int_table_html\ template (univariate case)
- The template is for univariate analysis and should not include independent variables

## Issue
The \int_table_html\ template for univariate analysis was incorrectly including an \indep\ parameter in the \makeme\ call, which should only be present in bivariate templates.