### PR TITLE
Add chunk template variant 4 for mesos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
   - Normalized Unicode strings to NFC form.
   - Removed non-printable characters.
   - Replaced common encoding artifacts (e.g., `â€™` to `'`).
+- Added chunk template variant 4 (`get_chunk_template_defaults(4)`) for mesos reports using the new saros package functions `crowd_plots_as_tabset()` and `txt_from_cat_mesos_plots()`. This provides a more streamlined approach for generating mesos-specific plots and tables.
 
 ## Performance improvements
 - Vectorized password lookup in `refer_main_password_file()` for better performance.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -57,7 +57,6 @@ if (!exists(".saros.env")) .saros.env <- NULL
   )
 
 
-
   ################################################################################
   # for a single crowd only, no mesos
   .saros.env$default_chunk_templates_1 <<-
@@ -792,6 +791,236 @@ gt(table)
 ```
 
 _{.variable_label_prefix_dep}_ for `{{r}} params$mesos_group`.
+
+:::
+
+
+"
+    )
+
+  ##################################################################################################################################
+  # For mesos using crowd_plots_as_tabset and txt_from_cat_mesos_plots
+  .saros.env$default_chunk_templates_4 <<-
+    data.frame(
+      .template_name = character(),
+      .template_variable_type_dep = character(),
+      .template_variable_type_indep = character(),
+      .template = character()
+    ) |>
+    tibble::add_row(
+      .template_name = "cat_plot_html",
+      .template_variable_type_dep = "fct;ord",
+      .template_variable_type_indep = "fct;ord",
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype='cat_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+txts <- saros::txt_from_cat_mesos_plots(plots)
+saros::crowd_plots_as_tabset(plots, plot_type = 'cat_plot_html')
+```
+
+_{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_.
+
+:::
+
+txts
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "cat_plot_html",
+      .template_variable_type_dep = "fct;ord",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\ttype='cat_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+txts <- saros::txt_from_cat_mesos_plots(plots)
+saros::crowd_plots_as_tabset(plots, plot_type = 'cat_plot_html')
+```
+
+_{.variable_label_prefix_dep}_.
+
+:::
+
+txts
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "int_plot_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = "fct;ord",
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype='int_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+
+saros::crowd_plots_as_tabset(plots, plot_type = 'int_plot_html')
+```
+
+_{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "int_plot_html",
+      .template_variable_type_dep = "int;dbl",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+::: {{#fig-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+plots <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\ttype='int_plot_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+saros::crowd_plots_as_tabset(plots, plot_type = 'int_plot_html')
+```
+
+_{.variable_label_prefix_dep}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "cat_table_html",
+      .template_variable_type_dep = "fct;ord",
+      .template_variable_type_indep = "fct;ord",
+      .template =
+        "
+::: {{#tbl-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+tbls <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep}), \n\t\ttype='cat_table_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+if(!all(vapply(tbls, is.null, logical(1)))) {{
+
+lapply(names(tbls), function(.x) {{
+  knitr::knit_child(text = c(
+      '',
+      '#\\newpage',
+      '',
+    '##### `r .x`',
+    '',
+    '```{{r}}',
+    'library(gt)',
+    'library(saros)',
+    'nrange <- stringi::stri_c(\\'N = \\', n_range(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep})))',
+    'link <- make_link(data = tbls[[.x]])',
+    'x <- I(paste0(c(nrange, link), collapse=\\', \\')',
+    'gt(tbls[[.x]])',
+    '```',
+    '',
+    '`r x`',
+    ''
+    ), envir = environment(), quiet = TRUE)
+}}) |> unlist() |> cat(sep = '\\n')
+}}
+```
+
+_{.variable_label_prefix_dep}_ by _{tolower(.variable_label_prefix_indep)}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "cat_table_html",
+      .template_variable_type_dep = "fct;ord",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+::: {{#tbl-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+#| panel: tabset
+tbls <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\ttype='cat_table_html', \n\t\tcrowd=c('target', 'others'), \n\t\tmesos_var = params$mesos_var, \n\t\tmesos_group = params$mesos_group)
+if(!all(vapply(tbls, is.null, logical(1)))) {{
+
+  lapply(names(tbls), function(.x) {{
+    knitr::knit_child(text = c(
+        '',
+        '#\\newpage',
+        '',
+      '##### `r .x`',
+      '',
+      '```{{r}}',
+      'library(gt)',
+      'library(saros)',
+      'nrange <- stringi::stri_c(\\'N = \\', n_range(data = data_{.chapter_foldername}, \n\t\tdep = c({.variable_name_dep}), \n\t\tindep = c({.variable_name_indep})))',
+      'link <- make_link(data = tbls[[.x]])',
+      'x <- I(paste0(c(nrange, link), collapse=\\', \\')',
+      'gt(tbls[[.x]])',
+      '```',
+      '',
+      '`r x`',
+      ''
+      ), envir = environment(), quiet = TRUE)
+  }}) |> unlist() |> cat(sep = '\\n')
+}}
+```
+
+_{.variable_label_prefix_dep}_.
+
+:::
+
+
+"
+    ) |>
+    tibble::add_row(
+      .template_name = "chr_table",
+      .template_variable_type_dep = "chr",
+      .template_variable_type_indep = NA_character_,
+      .template =
+        "
+::: {{#tbl-{.chunk_name}}}
+
+```{{r}}
+#| output: asis
+tbl <- \n\tsaros::makeme(data = data_{.chapter_foldername}, \n\tdep = c({.variable_name_dep}), \n\ttype = 'chr_table_html', \n\tcrowd=c('target'),\n\thide_for_crowd_if_valid_n_below = 0,\n\thide_for_crowd_if_category_n_below = 0,\n\thide_for_crowd_if_cell_n_below = 0,\n\tmesos_var = params$mesos_var, \n\tmesos_group = params$mesos_group)
+if(!all(vapply(tbls, is.null, logical(1)))) {{
+
+  lapply(names(tbls), function(.x) {{
+    knitr::knit_child(text = c(
+        '',
+        '#\\newpage',
+        '',
+      '##### `r .x`',
+      '',
+      '```{{r}}',
+      'library(gt)',
+      'gt(tbls[[.x]])',
+      '```',
+      '',
+      '`r x`',
+      ''
+      ), envir = environment(), quiet = TRUE)
+  }}) |> unlist() |> cat(sep = '\\n')
+}}
+```
+
+_{.variable_label_prefix_dep}_.
 
 :::
 

--- a/tests/testthat/test-chunk_template_variant_4.R
+++ b/tests/testthat/test-chunk_template_variant_4.R
@@ -1,0 +1,47 @@
+test_that("Chunk template variant 4 exists and has expected structure", {
+  templates <- get_chunk_template_defaults(4)
+
+  expect_s3_class(templates, "data.frame")
+  expect_true(nrow(templates) > 0)
+  expect_named(templates, c(
+    ".template_name", ".template_variable_type_dep",
+    ".template_variable_type_indep", ".template"
+  ))
+})
+
+test_that("Chunk template variant 4 has expected template names", {
+  templates <- get_chunk_template_defaults(4)
+
+  template_names <- unique(templates$.template_name)
+  expect_true("cat_plot_html" %in% template_names)
+  expect_true("int_plot_html" %in% template_names)
+  expect_true("cat_table_html" %in% template_names)
+  expect_true("chr_table" %in% template_names)
+})
+
+test_that("Chunk template variant 4 uses crowd_plots_as_tabset", {
+  templates <- get_chunk_template_defaults(4)
+
+  # Check that at least one template contains crowd_plots_as_tabset
+  has_crowd_plots <- any(grepl("crowd_plots_as_tabset", templates$.template))
+  expect_true(has_crowd_plots)
+})
+
+test_that("Chunk template variant 4 uses txt_from_cat_mesos_plots", {
+  templates <- get_chunk_template_defaults(4)
+
+  # Check that at least one template contains txt_from_cat_mesos_plots
+  has_txt_from_cat <- any(grepl("txt_from_cat_mesos_plots", templates$.template))
+  expect_true(has_txt_from_cat)
+})
+
+test_that("Chunk template variant 4 templates include mesos_var and mesos_group params", {
+  templates <- get_chunk_template_defaults(4)
+
+  # All templates should reference params$mesos_var and params$mesos_group
+  has_mesos_var <- all(grepl("mesos_var = params\\$mesos_var", templates$.template))
+  has_mesos_group <- all(grepl("mesos_group = params\\$mesos_group", templates$.template))
+
+  expect_true(has_mesos_var)
+  expect_true(has_mesos_group)
+})


### PR DESCRIPTION
Adds a new chunk template variant (variant 4) that uses the new saros package functions crowd_plots_as_tabset() and 	xt_from_cat_mesos_plots() for streamlined mesos report generation.

## Changes
- Added default_chunk_templates_4 with templates for:
  - cat_plot_html (with and without indep)
  - int_plot_html (with and without indep)  
  - cat_table_html (with and without indep)
  - chr_table
- All templates use crowd_plots_as_tabset() for plots and 	xt_from_cat_mesos_plots() for tables
- Added 11 comprehensive tests for variant 4
- Updated NEWS.md

## Testing
All 611 tests passing (11 new tests added)