### PR TITLE
Remove unused filename_prefix param from draft_report()

### DIFF
--- a/R/draft_report.R
+++ b/R/draft_report.R
@@ -251,7 +251,6 @@ draft_report <-
            auxiliary_variables = NULL,
            serialized_format = "rds", # For attach_chapter_dataset
            max_path_warning_threshold = 260, # Tidy up argument name: max_width_path_warning. Keep here
-           filename_prefix = "",
            data_filename_prefix = "data_",
            report_includes_prefix = '{{< include "',
            report_includes_suffix = '" >}}',

--- a/R/validate_draft_report_args.R
+++ b/R/validate_draft_report_args.R
@@ -46,7 +46,6 @@ get_draft_report_validation_rules <- function(params, env, core_chapter_structur
     replace_heading_for_group = list(fun = function(x) is.null(x) || (is.character(x) && rlang::is_named(x) && sum(duplicated(names(x))) == 0)),
     prefix_heading_for_group = list(fun = function(x) is.null(x) || (is.character(x) && rlang::is_named(x) && sum(duplicated(names(x))) == 0)),
     suffix_heading_for_group = list(fun = function(x) is.null(x) || (is.character(x) && rlang::is_named(x) && sum(duplicated(names(x))) == 0)),
-    filename_prefix = list(fun = function(x) is_string(x) || is.null(x)),
     data_filename_prefix = list(fun = function(x) is_string(x) || is.null(x)),
     report_includes_prefix = list(fun = function(x) is_string(x)),
     report_includes_suffix = list(fun = function(x) is_string(x)),

--- a/man/draft_report.Rd
+++ b/man/draft_report.Rd
@@ -37,7 +37,6 @@ draft_report(
   auxiliary_variables = NULL,
   serialized_format = "rds",
   max_path_warning_threshold = 260,
-  filename_prefix = "",
   data_filename_prefix = "data_",
   report_includes_prefix = "{{< include \\"",
   report_includes_suffix = "\\" >}}",
@@ -205,13 +204,6 @@ file paths. This will mean that files with cache (hash suffixes are added) will
 quickly breach this limit. When set, a warning will be returned if files are found
 to be longer than this threshold. Also note that spaces count as three characters
 due to its URL-conversion: \%20. To avoid test, set to Inf}
-
-\item{filename_prefix}{\emph{Prefix string for all qmd filenames}
-
-\verb{scalar<character>} // \emph{default:} \code{""} (\code{optional})
-
-For mesos setup it might be useful to set these files (and related sub-folders) with an underscore
-(\code{filename_prefix = "_"}) in front as other stub files will include these main qmd files.}
 
 \item{data_filename_prefix}{\emph{String attached to beginning of data-file and data-object}
 

--- a/man/gen_qmd_chapters.Rd
+++ b/man/gen_qmd_chapters.Rd
@@ -109,13 +109,6 @@ chapter qmd-files, if \code{attach_chapter_dataset=TRUE}. Not publicly available
 Format for serialized data when storing chapter dataset.
 Currently only \code{"rds"} is supported.}
 
-\item{filename_prefix}{\emph{Prefix string for all qmd filenames}
-
-\verb{scalar<character>} // \emph{default:} \code{""} (\code{optional})
-
-For mesos setup it might be useful to set these files (and related sub-folders) with an underscore
-(\code{filename_prefix = "_"}) in front as other stub files will include these main qmd files.}
-
 \item{data_filename_prefix}{\emph{String attached to beginning of data-file and data-object}
 
 \verb{scalar<string>} // \emph{default:} \code{"data_"}}


### PR DESCRIPTION
## Summary
- Remove `filename_prefix` from `draft_report()` signature and validation
- The parameter was accepted but never passed through to `gen_qmd_chapters()`, making it dead code
- It remains in `refine_chapter_overview()` where it is actually consumed

Closes #190

## Test plan
- [x] `R CMD check`: 0 errors, 0 warnings, 0 notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)