### PR TITLE
Fix bugs and replace browser() calls with proper errors

### DIFF
--- a/R/create_directory_structure.R
+++ b/R/create_directory_structure.R
@@ -19,14 +19,14 @@ handle_naming_conventions <- function(name = "Journal manuscripts",
       "upper" = stringi::stri_trans_toupper(name),
       "title" = stringi::stri_trans_totitle(name),
       "snake" =
-        stringi::stri_replace_all_fixed(stringi::stri_trans_totitle(name),
-          pattern = " ", replacement = ""
+        stringi::stri_replace_all_regex(stringi::stri_trans_tolower(name),
+          pattern = "[[:space:]]+", replacement = "_"
         )
     )
 
   # Replace spaces. CONSIDER CHANGING " " TO EVERYTHING NON-ALPHANUMERIC?
   if (rlang::is_string(word_separator)) {
-    name <- stringi::stri_replace_all_fixed(name, pattern = "[[:space:]]+", replacement = word_separator)
+    name <- stringi::stri_replace_all_regex(name, pattern = "[[:space:]]+", replacement = word_separator)
   }
   for (i in seq_along(replacement_list)) {
     name <- stringi::stri_replace_all_fixed(name,
@@ -154,7 +154,9 @@ create_directory_structure <- function(
   if (numbering_prefix == "max_global") {
     max_folder_count_digits <- find_longest_list_length(folder_structure)
     max_folder_count_digits <- floor(log10(max_folder_count_digits)) + 1
-    if (max_folder_count_digits == -Inf) browser()
+    if (max_folder_count_digits == -Inf) {
+      cli::cli_abort("Internal error: {.arg max_folder_count_digits} is {.val -Inf}, indicating an empty folder structure.")
+    }
   } else {
     max_folder_count_digits <- 0
   }

--- a/R/create_directory_structure.R
+++ b/R/create_directory_structure.R
@@ -24,9 +24,12 @@ handle_naming_conventions <- function(name = "Journal manuscripts",
         )
     )
 
-  # Replace spaces. CONSIDER CHANGING " " TO EVERYTHING NON-ALPHANUMERIC?
+  # Replace whitespace runs with word_separator
   if (rlang::is_string(word_separator)) {
-    name <- stringi::stri_replace_all_regex(name, pattern = "[[:space:]]+", replacement = word_separator)
+    # Escape $ and \ so they are treated literally in ICU regex replacement
+    escaped_sep <- stringi::stri_replace_all_fixed(word_separator, "\\", "\\\\")
+    escaped_sep <- stringi::stri_replace_all_fixed(escaped_sep, "$", "\\$")
+    name <- stringi::stri_replace_all_regex(name, pattern = "[[:space:]]+", replacement = escaped_sep)
   }
   for (i in seq_along(replacement_list)) {
     name <- stringi::stri_replace_all_fixed(name,

--- a/R/gen_qmd_structure.R
+++ b/R/gen_qmd_structure.R
@@ -17,8 +17,6 @@ gen_qmd_structure <-
 
 
       for (value in unique(grouped_data[[level]])) {
-        # if(!is.na(value) && value == "x1_sex") browser()
-
 
         # Keep only relevant part of meta data which will be forwarded into a deeper level
         sub_df <-
@@ -89,8 +87,6 @@ gen_qmd_structure <-
         output <-
           if (length(output) > 0) output else ""
       }
-      if (length(output) > 1) browser()
-
       if (length(output) != 1 || is.na(output)) {
         cli::cli_abort(c(
           "x" = "Internal error in {.fn gen_qmd_structure}",

--- a/R/get_common_levels.R
+++ b/R/get_common_levels.R
@@ -1,5 +1,4 @@
 get_common_levels <- function(data, col_pos=NULL) {
-  # if(length(col_pos)==1 && any(col_pos == "open_comments") && is.factor(data$open_comments)) browser()
   if(any(is.na(col_pos))) cli::cli_abort("{.arg col_pos} cannot be NA.")
   data_out <- if(!inherits(data, "survey.design")) data[, col_pos, drop=FALSE] else data$variables[, col_pos, drop=FALSE]
   if(lapply(data_out, function(x) inherits(x, "factor")) |>
@@ -9,7 +8,6 @@ get_common_levels <- function(data, col_pos=NULL) {
     return(levels(fct_unions))
   }
   if(length(get_common_data_type(data_out)) > 1 && length(col_pos)>1) {
-    # browser()
     cli::cli_abort(c(x="{.arg data} contains columns without a common data type.",
                      i="Problem with: {.val {colnames(data_out)}};",
                      i="which have the types {.val {get_common_data_type(data_out)}}."))

--- a/R/look_for_extended.R
+++ b/R/look_for_extended.R
@@ -102,7 +102,11 @@ look_for_extended <- function(data,
   if (length(.variable_position) != length(.variable_name) ||
     length(.variable_name) != length(.variable_label) ||
     length(.variable_label) != length(.variable_type)) {
-    browser()
+    cli::cli_abort(c(
+      "x" = "Internal error in {.fn look_for_extended}: mismatched vector lengths.",
+      "i" = "Lengths: position={length(.variable_position)}, name={length(.variable_name)}, label={length(.variable_label)}, type={length(.variable_type)}",
+      "i" = "Please report at {.url https://github.com/NIFU-NO/saros.base/issues}."
+    ))
   }
 
   x <- data.frame(

--- a/R/remove_from_chapter_structure_if_non_significant.R
+++ b/R/remove_from_chapter_structure_if_non_significant.R
@@ -50,7 +50,10 @@ remove_from_chapter_structure_if_non_significant <-
             if (is.null(df_col_row$.variable_name_dep) ||
               length(df_col_row$.variable_name_dep) == 0 ||
               is.na(df_col_row$.variable_name_dep)) {
-              browser()
+              cli::cli_abort(c(
+                "x" = "Internal error: {.var .variable_name_dep} is NULL, empty, or NA in bivariate filtering.",
+                "i" = "Please report at {.url https://github.com/NIFU-NO/saros.base/issues}."
+              ))
             }
 
             df_chitest <-

--- a/R/remove_from_chapter_structure_if_non_significant.R
+++ b/R/remove_from_chapter_structure_if_non_significant.R
@@ -51,7 +51,7 @@ remove_from_chapter_structure_if_non_significant <-
               length(df_col_row$.variable_name_dep) == 0 ||
               is.na(df_col_row$.variable_name_dep)) {
               cli::cli_abort(c(
-                "x" = "Internal error: {.var .variable_name_dep} is NULL, empty, or NA in bivariate filtering.",
+                "x" = "Internal error: column {.val .variable_name_dep} is NULL, empty, or NA in bivariate filtering.",
                 "i" = "Please report at {.url https://github.com/NIFU-NO/saros.base/issues}."
               ))
             }

--- a/R/validate_path_lengths_on_win.R
+++ b/R/validate_path_lengths_on_win.R
@@ -5,7 +5,7 @@ validate_path_lengths_on_win <-
       nchar(list.files(path=path,
                        all.files = TRUE, full.names = TRUE, recursive = TRUE))
     if(.Platform$OS.type == "windows" && max(max_paths, na.rm=TRUE) >= max_path_warning_threshold) {
-      cli::cli_warn(c(x="{.val {length(max_path[max_path >= max_path_warning_threshold])}} files exceed {.arg max_path_warning_threshold} ({max_path_warning_threshold}) characters.",
+      cli::cli_warn(c(x="{.val {length(max_paths[max_paths >= max_path_warning_threshold])}} files exceed {.arg max_path_warning_threshold} ({max_path_warning_threshold}) characters.",
                       i="This may create problems in Windows if path is on a Sharepoint/OneDrive.",
                       i="Omit warning by adjusting {.arg max_path_warning_threshold}"))
     }

--- a/tests/testthat/test-create_directory_structure.R
+++ b/tests/testthat/test-create_directory_structure.R
@@ -19,26 +19,21 @@ testthat::test_that("handle_naming_conventions applies correct case transformati
   result <- saros.base:::handle_naming_conventions("hello world", case = "title")
   testthat::expect_equal(result, "Hello World")
   
-  # Test snake case (removes spaces)
+  # Test snake case (lowercase with underscores)
   result <- saros.base:::handle_naming_conventions("hello world test", case = "snake")
-  testthat::expect_equal(result, "HelloWorldTest")
+  testthat::expect_equal(result, "hello_world_test")
 })
 
 testthat::test_that("handle_naming_conventions applies word separators", {
-  # Note: word_separator replacement does NOT use regex, it's literal string replacement
-  # The pattern "[[:space:]]+" is treated as literal text, not regex
-  # So this feature may not work as intended in the current implementation
-  
-  # Test that function runs without error
-  result <- saros.base:::handle_naming_conventions("Hello World", 
+  result <- saros.base:::handle_naming_conventions("Hello World",
                                                    case = "lower",
                                                    word_separator = "_")
-  testthat::expect_type(result, "character")
-  
-  result <- saros.base:::handle_naming_conventions("Hello World Test", 
+  testthat::expect_equal(result, "hello_world")
+
+  result <- saros.base:::handle_naming_conventions("Hello World Test",
                                                    case = "asis",
                                                    word_separator = "-")
-  testthat::expect_type(result, "character")
+  testthat::expect_equal(result, "Hello-World-Test")
 })
 
 testthat::test_that("handle_naming_conventions applies replacement list", {


### PR DESCRIPTION
## Summary
- **#196**: Fix variable name typo `max_path` → `max_paths` in `validate_path_lengths_on_win.R` (runtime error on Windows when threshold exceeded)
- **#197**: Fix `stri_replace_all_fixed` used with regex pattern `[[:space:]]+` — spaces were never actually replaced by `word_separator`
- **#198**: Replace `browser()` with `cli::cli_abort()` in `create_directory_structure.R` (hung non-interactive sessions)
- **#199**: Remove `browser()` that blocked `cli_abort` from firing in `gen_qmd_structure.R`
- **#200**: Replace `browser()` with `cli::cli_abort()` in `look_for_extended.R`
- **#201**: Replace `browser()` with `cli::cli_abort()` in `remove_from_chapter_structure_if_non_significant.R`
- **#202**: Remove 3 commented-out `browser()` calls from `get_common_levels.R` and `gen_qmd_structure.R`
- **#203**: Fix `"snake"` case option to produce actual `snake_case` (was producing PascalCase)

Closes #196, closes #197, closes #198, closes #199, closes #200, closes #201, closes #202, closes #203

## Test plan
- [x] All 611 existing tests pass
- [x] Updated test for `handle_naming_conventions` snake case to expect correct `"hello_world_test"` output
- [x] Updated test for `word_separator` to verify actual replacement behavior
- [ ] Verify on CI (R-CMD-check across platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)