### PR TITLE
Fix package failing to load without 'tibble' (#215)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     forcats,
     fs,
     yaml,
+    tibble,
 	zip,
     rstudioapi,
     bcrypt
@@ -54,7 +55,6 @@ Suggests:
     quarto,
     labelled,
     testthat (>= 3.0.0),
-	tibble,
     withr,
     spelling
 SystemRequirements: None.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # saros.base 1.2.1.9001
 
+## Bug fixes
+- Moved `tibble` from `Suggests` to `Imports` (#215). `.onLoad()` builds the default chunk templates with `tibble::add_row()`, so the package could not be attached at all on installations without `tibble` (e.g. `install.packages()` without `dependencies = TRUE`). No new installation burden: `dplyr` already imports `tibble`.
+- Suggested packages are now used conditionally, per R-exts (#215). `srvyr` (in `ungroup_data()`) and `writexl`/`readr`/`haven` (in `tabular_write()`) are guarded with `rlang::check_installed()`, which reports an actionable install prompt instead of "there is no package called ...". The single `purrr::compact()` call was replaced with base R.
+
 ## New features
 - Added `default_chunk_templates_5`: a new simplified template set for single crowd reports without mesos structure. Uses cleaner helper functions like `get_fig_title_suffix_from_ggplot()` for more streamlined code generation.
 

--- a/R/pretty_tabular.R
+++ b/R/pretty_tabular.R
@@ -1,12 +1,27 @@
-
 tabular_write <- function(object, path, format) {
+  # `writexl`, `readr` and `haven` are in Suggests, so their availability must be
+  # checked before use (R-exts: "Packages in Suggests should be used conditionally").
+  pkg <- switch(format,
+    xlsx = "writexl",
+    csv = ,
+    csv2 = ,
+    tsv = "readr",
+    sav = ,
+    dta = "haven",
+    NULL
+  )
+  if (!is.null(pkg)) {
+    rlang::check_installed(pkg, reason = paste0("to write ", format, " files."))
+  }
+
   switch(format,
-         delim = utils::write.table(x = object, file = path, sep = "\t", row.names = FALSE, col.names = TRUE),
-         xlsx = writexl::write_xlsx(x = object, path = path),
-         csv = readr::write_csv(x = object, file = path),
-         csv2 = readr::write_csv2(x = object, file = path),
-         tsv = readr::write_tsv(x = object, file = path),
-         sav = haven::write_sav(data = object, path = path),
-         dta = haven::write_dta(data = object, path = path)
+    delim = utils::write.table(x = object, file = path, sep = "\t", row.names = FALSE, col.names = TRUE),
+    xlsx = writexl::write_xlsx(x = object, path = path),
+    csv = readr::write_csv(x = object, file = path),
+    csv2 = readr::write_csv2(x = object, file = path),
+    tsv = readr::write_tsv(x = object, file = path),
+    sav = haven::write_sav(data = object, path = path),
+    dta = haven::write_dta(data = object, path = path),
+    cli::cli_abort("Unsupported {.arg format}: {.val {format}}.")
   )
 }

--- a/R/pretty_tabular.R
+++ b/R/pretty_tabular.R
@@ -1,27 +1,37 @@
 tabular_write <- function(object, path, format) {
-  # `writexl`, `readr` and `haven` are in Suggests, so their availability must be
-  # checked before use (R-exts: "Packages in Suggests should be used conditionally").
-  pkg <- switch(format,
-    xlsx = "writexl",
-    csv = ,
-    csv2 = ,
-    tsv = "readr",
-    sav = ,
-    dta = "haven",
-    NULL
-  )
-  if (!is.null(pkg)) {
-    rlang::check_installed(pkg, reason = paste0("to write ", format, " files."))
-  }
-
+  # `writexl`, `readr` and `haven` are in Suggests, so availability is checked
+  # immediately before each use (R-exts: "Packages in Suggests should be used
+  # conditionally"). The guards are inline, one per branch, so each names the
+  # package it protects and cannot drift away from the call it guards.
   switch(format,
-    delim = utils::write.table(x = object, file = path, sep = "\t", row.names = FALSE, col.names = TRUE),
-    xlsx = writexl::write_xlsx(x = object, path = path),
-    csv = readr::write_csv(x = object, file = path),
-    csv2 = readr::write_csv2(x = object, file = path),
-    tsv = readr::write_tsv(x = object, file = path),
-    sav = haven::write_sav(data = object, path = path),
-    dta = haven::write_dta(data = object, path = path),
+    delim = utils::write.table(
+      x = object, file = path, sep = "\t",
+      row.names = FALSE, col.names = TRUE
+    ),
+    xlsx = {
+      rlang::check_installed("writexl", reason = "to write xlsx files.")
+      writexl::write_xlsx(x = object, path = path)
+    },
+    csv = {
+      rlang::check_installed("readr", reason = "to write csv files.")
+      readr::write_csv(x = object, file = path)
+    },
+    csv2 = {
+      rlang::check_installed("readr", reason = "to write csv2 files.")
+      readr::write_csv2(x = object, file = path)
+    },
+    tsv = {
+      rlang::check_installed("readr", reason = "to write tsv files.")
+      readr::write_tsv(x = object, file = path)
+    },
+    sav = {
+      rlang::check_installed("haven", reason = "to write sav files.")
+      haven::write_sav(data = object, path = path)
+    },
+    dta = {
+      rlang::check_installed("haven", reason = "to write dta files.")
+      haven::write_dta(data = object, path = path)
+    },
     cli::cli_abort("Unsupported {.arg format}: {.val {format}}.")
   )
 }

--- a/R/setup_mesos_structure.R
+++ b/R/setup_mesos_structure.R
@@ -234,7 +234,7 @@ handle_data_frame <- function(mesos_groups) {
     cli::cli_abort("{.arg mesos_groups} data frame has no columns.")
   }
 
-  lapply(seq_len(ncol(mesos_groups)), function(i) {
+  out <- lapply(seq_len(ncol(mesos_groups)), function(i) {
     col_data <- clean_group_data(mesos_groups[[i]])
     col_name <- names(mesos_groups)[i]
 
@@ -249,7 +249,9 @@ handle_data_frame <- function(mesos_groups) {
     }
 
     df
-  }) |> purrr::compact()
+  })
+
+  Filter(Negate(is.null), out)
 }
 
 # Helper function to clean group data

--- a/R/ungroup_data.R
+++ b/R/ungroup_data.R
@@ -1,5 +1,8 @@
 ungroup_data <- function(data) {
-  if(inherits(data, "survey")) {
-     srvyr::ungroup(data)
-  } else dplyr::ungroup(data)
+  if (inherits(data, "survey")) {
+    rlang::check_installed("srvyr", reason = "to ungroup survey objects.")
+    srvyr::ungroup(data)
+  } else {
+    dplyr::ungroup(data)
+  }
 }

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -33,7 +33,13 @@ test_that("Suggests-only packages are used conditionally in R/", {
   skip_on_cran()
 
   r_dir <- test_path("..", "..", "R")
-  skip_if_not(dir.exists(r_dir), "source tree not available (installed package)")
+  # An *installed* package also has an R/ directory, but it holds saros.base.rdb
+  # rather than sources -- so presence of the directory is not enough, and
+  # scanning it would otherwise pass vacuously.
+  skip_if(
+    length(list.files(r_dir, pattern = "[.][Rr]$")) == 0,
+    "no R/ sources available (running against an installed package)"
+  )
 
   suggests_only <- setdiff(description_deps("Suggests"), description_deps("Imports"))
   skip_if(length(suggests_only) == 0, "no Suggests-only packages declared")

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -1,0 +1,58 @@
+# Helpers -------------------------------------------------------------------
+
+# Parsed dependency field from the package DESCRIPTION, without version
+# constraints. Returns character(0) if the field is absent.
+description_deps <- function(field) {
+  desc_path <- test_path("..", "..", "DESCRIPTION")
+  skip_if_not(file.exists(desc_path), "source tree not available (installed package)")
+
+  desc <- read.dcf(desc_path)
+  if (!field %in% colnames(desc) || is.na(desc[, field])) {
+    return(character())
+  }
+  trimws(gsub("\\(.*?\\)", "", strsplit(desc[, field], ",")[[1]]))
+}
+
+# Tests ---------------------------------------------------------------------
+
+test_that("tibble is declared in Imports, because .onLoad() uses it", {
+  # Guards GH #215: `.onLoad()` builds the default chunk templates with
+  # `tibble::add_row()`. A package whose `.onLoad()` errors cannot be attached
+  # at all, so this dependency must be hard, not suggested.
+  skip_on_cran()
+  expect_true("tibble" %in% description_deps("Imports"))
+})
+
+test_that("Suggests-only packages are used conditionally in R/", {
+  # R-exts: "Packages in Suggests should be used conditionally." A file is
+  # compliant if it calls rlang::check_installed() before reaching for one.
+  skip_on_cran()
+
+  r_dir <- test_path("..", "..", "R")
+  skip_if_not(dir.exists(r_dir), "source tree not available (installed package)")
+
+  suggests_only <- setdiff(description_deps("Suggests"), description_deps("Imports"))
+  skip_if(length(suggests_only) == 0, "no Suggests-only packages declared")
+
+  offenders <- character()
+  for (file in list.files(r_dir, pattern = "[.][Rr]$", full.names = TRUE)) {
+    src <- readLines(file, warn = FALSE)
+    src <- src[!grepl("^\\s*#", src)] # roxygen and ordinary comments
+    src <- gsub("\\{\\.[a-z_]+ [^}]*\\}", "", src) # cli inline markup, e.g. {.fun pkg::f}
+
+    used <- unique(unlist(regmatches(
+      src,
+      gregexpr("[A-Za-z][A-Za-z0-9._]*(?=::)", src, perl = TRUE)
+    )))
+    unguarded <- intersect(used, suggests_only)
+
+    if (length(unguarded) > 0 && !any(grepl("check_installed", src, fixed = TRUE))) {
+      offenders <- c(
+        offenders,
+        paste0(basename(file), ": ", paste(unguarded, collapse = ", "))
+      )
+    }
+  }
+
+  expect_equal(offenders, character(0))
+})

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -24,8 +24,12 @@ test_that("tibble is declared in Imports, because .onLoad() uses it", {
 })
 
 test_that("Suggests-only packages are used conditionally in R/", {
-  # R-exts: "Packages in Suggests should be used conditionally." A file is
-  # compliant if it calls rlang::check_installed() before reaching for one.
+  # R-exts: "Packages in Suggests should be used conditionally."
+  #
+  # Each Suggests-only package used in a file must be named as a string literal
+  # in a check_installed() call in that same file. Associating the guard with
+  # the specific package -- rather than accepting any check_installed() anywhere
+  # in the file -- stops one guarded package from vouching for an unguarded one.
   skip_on_cran()
 
   r_dir <- test_path("..", "..", "R")
@@ -44,15 +48,29 @@ test_that("Suggests-only packages are used conditionally in R/", {
       src,
       gregexpr("[A-Za-z][A-Za-z0-9._]*(?=::)", src, perl = TRUE)
     )))
-    unguarded <- intersect(used, suggests_only)
 
-    if (length(unguarded) > 0 && !any(grepl("check_installed", src, fixed = TRUE))) {
-      offenders <- c(
-        offenders,
-        paste0(basename(file), ": ", paste(unguarded, collapse = ", "))
-      )
+    for (pkg in intersect(used, suggests_only)) {
+      guard <- paste0("check_installed\\(\\s*[\"']", pkg, "[\"']")
+      if (!any(grepl(guard, src))) {
+        offenders <- c(offenders, paste0(basename(file), ": ", pkg))
+      }
     }
   }
 
   expect_equal(offenders, character(0))
+})
+
+test_that("the Suggests guard detector rejects a cross-vouching file", {
+  # Guards the guard: a file that guards one package must not thereby be
+  # treated as guarding another.
+  src <- c(
+    'rlang::check_installed("srvyr", reason = "to ungroup survey objects.")',
+    "srvyr::ungroup(data)",
+    "haven::write_sav(data, path)" # unguarded
+  )
+  guarded <- function(pkg) {
+    any(grepl(paste0("check_installed\\(\\s*[\"']", pkg, "[\"']"), src))
+  }
+  expect_true(guarded("srvyr"))
+  expect_false(guarded("haven"))
 })


### PR DESCRIPTION
Fixes #215.

## The load-blocking bug

`.onLoad()` (`R/zzz.R:6-1213`) builds the five default chunk-template tables with ~40 `tibble::add_row()` calls, but `tibble` was declared in `Suggests`. A package whose `.onLoad()` errors cannot be attached at all, so `library(saros.base)` failed outright wherever `tibble` was absent — including plain `install.packages("saros.base")`, which does **not** install Suggests.

Standard `R CMD check` installs Suggests and therefore passed. CRAN's `_R_CHECK_DEPENDS_ONLY_=true` run would not have.

**Fix:** `tibble` → `Imports`. Zero installation cost — `dplyr` is already in `Imports` and itself imports `tibble (>= 3.2.0)`, so `tibble` is present on every installation already. This just makes the existing reality honest, and avoids a ~1000-line rewrite of `.onLoad()` for no dependency saving.

## Remaining unconditional Suggests usage

R-exts requires Suggests to be used conditionally. Three other sites did not:

| location | package | change |
|---|---|---|
| `R/setup_mesos_structure.R` | `purrr::compact()` | replaced with base `Filter(Negate(is.null), ...)` |
| `R/ungroup_data.R` | `srvyr::ungroup()` | guarded with `rlang::check_installed()` |
| `R/pretty_tabular.R` | `writexl`, `readr`, `haven` | guarded with `rlang::check_installed()` |

`purrr` stays in `Suggests` — `vignettes/vig_04_prepare_data.qmd` uses it. `tibble` is removed from `Suggests` now that it is in `Imports`.

`check_installed()` gives an actionable install prompt rather than an opaque `there is no package called 'haven'`.

## Incidental

`tabular_write()` gained a default `switch()` branch. It previously returned `NULL` silently for an unrecognised `format`; it now errors. The function is currently dead code (defined, never called), so this is not a behaviour change for any caller.

## Tests

New `tests/testthat/test-dependencies.R`:

- asserts `tibble` is in `Imports`;
- scans every `R/*.R` file and fails if it references a `Suggests`-only package without also calling `check_installed()`. Comment lines and cli inline markup (`{.fun labelled::set_variable_labels}`) are stripped first, so documentation mentions do not trip it.

Full suite: **611 passed, 0 failed, 0 warnings, 0 skipped.**

## Not included

No documentation or pkgdown changes — no exported signatures changed and no exports were added or removed.

Suggested CI follow-up (not in this PR): an `R CMD check` job with `_R_CHECK_DEPENDS_ONLY_=true`, which is what would have caught this originally.

> [!NOTE]
> `NEWS.md` may need a trivial conflict resolution if several of the review PRs land together — they all append under the same `1.2.1.9001` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdgNWZurxdarb8mXimt4zp