### PR TITLE
Remove broken, unused create_text_collapse() (#217)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,10 @@
 # saros.base 1.2.1.9001
 
-## Code quality improvements
-- Removed the unused and broken `create_text_collapse()` (#217). It read `formals(draft_report)$translations`, but `draft_report()` has no `translations` argument, so the last separator resolved to `NULL` and `c("a", "b", "c")` collapsed to `"a, bc"` rather than erroring. A new test asserts that every `formals(fn)$name` reference in `R/` names a real argument.
-
 ## New features
 - Added `default_chunk_templates_5`: a new simplified template set for single crowd reports without mesos structure. Uses cleaner helper functions like `get_fig_title_suffix_from_ggplot()` for more streamlined code generation.
 
 ## Code quality improvements
+- Removed the unused and broken `create_text_collapse()` (#217). It read `formals(draft_report)$translations`, but `draft_report()` has no `translations` argument, so the last separator resolved to `NULL` and `c("a", "b", "c")` collapsed to `"a, bc"` rather than erroring. A new test asserts that every `formals(fn)$name` reference in `R/` names a real argument.
 - Improved code formatting and readability in `.onLoad()` function for better maintainability.
 - Updated template references in `default_chunk_templates_4` for better consistency (using `data` instead of `data_{.chapter_foldername}`, added `save = parameters$save` parameter).
 - Better structured code blocks with consistent indentation and spacing.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # saros.base 1.2.1.9001
 
+## Code quality improvements
+- Removed the unused and broken `create_text_collapse()` (#217). It read `formals(draft_report)$translations`, but `draft_report()` has no `translations` argument, so the last separator resolved to `NULL` and `c("a", "b", "c")` collapsed to `"a, bc"` rather than erroring. A new test asserts that every `formals(fn)$name` reference in `R/` names a real argument.
+
 ## New features
 - Added `default_chunk_templates_5`: a new simplified template set for single crowd reports without mesos structure. Uses cleaner helper functions like `get_fig_title_suffix_from_ggplot()` for more streamlined code generation.
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,18 +30,6 @@ check_category_pairs <-
 
 
 
-create_text_collapse <-
-  function(text = NULL,
-           last_sep = NULL) {
-    if (!is_string(last_sep)) {
-      last_sep <-
-        eval(formals(draft_report)$translations)$last_sep
-    }
-    cli::ansi_collapse(text, sep2 = last_sep, last = last_sep)
-  }
-
-
-
 
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,12 +28,6 @@ check_category_pairs <-
     TRUE
   }
 
-
-
-
-
-
-
 trim_columns <- function(data, cols = c(
                            ".variable_label_prefix_dep", ".variable_label_prefix_dep",
                            ".variable_label_prefix_indep", ".variable_label_suffix_indep"

--- a/tests/testthat/test-formals_references.R
+++ b/tests/testthat/test-formals_references.R
@@ -10,7 +10,13 @@ test_that("every formals(fn)$name reference in R/ names a real argument", {
   skip_on_cran()
 
   r_dir <- test_path("..", "..", "R")
-  skip_if_not(dir.exists(r_dir), "source tree not available (installed package)")
+  # An *installed* package also has an R/ directory, but it holds saros.base.rdb
+  # rather than sources -- so presence of the directory is not enough, and
+  # scanning it would otherwise pass vacuously.
+  skip_if(
+    length(list.files(r_dir, pattern = "[.][Rr]$")) == 0,
+    "no R/ sources available (running against an installed package)"
+  )
 
   pattern <- "formals\\(\\s*([A-Za-z._][A-Za-z0-9._]*)\\s*\\)\\$([A-Za-z._][A-Za-z0-9._]*)"
 

--- a/tests/testthat/test-formals_references.R
+++ b/tests/testthat/test-formals_references.R
@@ -1,0 +1,50 @@
+# Regression test for GH #217.
+#
+# create_text_collapse() read `formals(draft_report)$translations`, but
+# draft_report() has no `translations` argument. eval(NULL)$last_sep is NULL, so
+# cli::ansi_collapse() silently dropped the final separator -- c("a","b","c")
+# collapsed to "a, bc" instead of erroring. The function has been removed; this
+# test stops the pattern from coming back anywhere else.
+
+test_that("every formals(fn)$name reference in R/ names a real argument", {
+  skip_on_cran()
+
+  r_dir <- test_path("..", "..", "R")
+  skip_if_not(dir.exists(r_dir), "source tree not available (installed package)")
+
+  pattern <- "formals\\(\\s*([A-Za-z._][A-Za-z0-9._]*)\\s*\\)\\$([A-Za-z._][A-Za-z0-9._]*)"
+
+  offenders <- character()
+  for (file in list.files(r_dir, pattern = "[.][Rr]$", full.names = TRUE)) {
+    src <- readLines(file, warn = FALSE)
+    src <- src[!grepl("^\\s*#", src)]
+
+    matches <- regmatches(src, gregexpr(pattern, src))
+    for (reference in unlist(matches)) {
+      parts <- regmatches(reference, regexec(pattern, reference))[[1]]
+      fn_name <- parts[2]
+      arg_name <- parts[3]
+
+      fn <- tryCatch(
+        get(fn_name, envir = asNamespace("saros.base")),
+        error = function(e) NULL
+      )
+      if (is.null(fn) || !is.function(fn)) {
+        offenders <- c(offenders, paste0(basename(file), ": ", fn_name, "() not found"))
+        next
+      }
+      if (!arg_name %in% names(formals(fn))) {
+        offenders <- c(
+          offenders,
+          paste0(basename(file), ": ", fn_name, "() has no argument '", arg_name, "'")
+        )
+      }
+    }
+  }
+
+  expect_equal(offenders, character(0))
+})
+
+test_that("create_text_collapse() is gone", {
+  expect_false(exists("create_text_collapse", envir = asNamespace("saros.base"), inherits = FALSE))
+})


### PR DESCRIPTION
Fixes #217.

## The bug

`R/utils.R` defined:

```r
create_text_collapse <- function(text = NULL, last_sep = NULL) {
  if (!is_string(last_sep)) {
    last_sep <- eval(formals(draft_report)$translations)$last_sep
  }
  cli::ansi_collapse(text, sep2 = last_sep, last = last_sep)
}
```

`draft_report()` has no `translations` argument. The chain degrades silently instead of erroring, because `$` on `NULL` returns `NULL`:

```
formals(draft_report)$translations  -> NULL
eval(NULL)                          -> NULL
NULL$last_sep                       -> NULL
```

so `cli::ansi_collapse()` received `sep2 = NULL, last = NULL`:

```r
create_text_collapse(c("a", "b", "c"))
#> "a, bc"
```

The final separator is dropped. Expected would be `"a, b and c"`.

## Why removal rather than repair

No callers anywhere:

```
grep -rn "create_text_collapse" R/ tests/
#> R/utils.R:33:create_text_collapse <-
```

Definition only. The translations mechanism it was written against no longer exists in `draft_report()`, and the package already uses `cli::ansi_collapse()` and cli's `{.val }` collapsing directly elsewhere. Repairing it would mean inventing a default for a function nothing calls.

## Tests

New `tests/testthat/test-formals_references.R` generalises the guard rather than just asserting the removal:

- scans `R/` for `formals(fn)$name` references and fails if `name` is not a real formal of `fn`, or if `fn` cannot be resolved in the namespace;
- asserts `create_text_collapse` is gone.

This is worth having as a standing check because the failure mode is *silent* — `$` on `NULL` yields `NULL` rather than raising, so a formal that is renamed or removed leaves callers quietly computing on `NULL`. The same pattern is used deliberately and correctly in `validate_draft_report_args.R`, which this test confirms.

Full suite: **611 passed, 0 failed, 0 warnings, 0 skipped.**

## Not included

No documentation or pkgdown changes — the function was internal and undocumented.

> [!NOTE]
> `NEWS.md` may need a trivial conflict resolution if several of the review PRs land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdgNWZurxdarb8mXimt4zp