### PR TITLE
Add snapshot tests of the generated .qmd output (#207, #208, #184, #216)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
 ## New features
 - Added `default_chunk_templates_5`: a new simplified template set for single crowd reports without mesos structure. Uses cleaner helper functions like `get_fig_title_suffix_from_ggplot()` for more streamlined code generation.
 
+## Testing
+- Added snapshot tests of the `.qmd` text `draft_report()` writes (`tests/testthat/test-qmd_snapshots.R`). Nothing previously asserted anything about the generated content — the existing test checks file counts and file *sizes* — which is why #207, #208/#184 and #216 all shipped. Each of those was re-introduced and confirmed to fail the new tests. Only possible now that #213 made the output deterministic; `test-anchor_determinism.R` pins that property separately.
+
 ## Code quality improvements
 - Moved `tibble` from `Suggests` to `Imports` (#215). `.onLoad()` builds the default chunk templates with `tibble::add_row()`, and R-exts requires a package to declare what its own code uses directly. This corrects the declaration; it does not change observable behaviour. `tibble` is a hard dependency of `dplyr`, `tidyr` and `forcats` — all already in `Imports` — so it has always been installed alongside saros.base, and no installation could have lacked it.
 - CI now fails when `man/` or `NAMESPACE` differ from what `roxygen2::roxygenise()` produces from the roxygen comments in `R/` (#219). This is the drift that hid `delete_freeze()`: `R CMD check` accepts a package whose `NAMESPACE` is missing an export — it is simply a package without that function — and pkgdown indexes `.Rd` topics rather than exports, so neither caught it.

--- a/tests/testthat/_snaps/qmd_snapshots.md
+++ b/tests/testthat/_snaps/qmd_snapshots.md
@@ -1,0 +1,330 @@
+# the set of generated files is stable
+
+    Code
+      cat(relative_files(path), sep = "\n")
+    Output
+      1_Trivsel.qmd
+      1_Trivsel/data_1_Trivsel.rds
+      2_Bakgrunn.qmd
+      2_Bakgrunn/data_2_Bakgrunn.rds
+      index.qmd
+      report.qmd
+
+# index.qmd and report.qmd carry the report title
+
+    Code
+      print_file(path, "index.qmd")
+    Output
+      == index.qmd ==
+      ---
+      title: Eksempelrapport
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      
+      ---
+      
+      
+    Code
+      print_file(path, "report.qmd")
+    Output
+      == report.qmd ==
+      ---
+      title: Eksempelrapport
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      
+      ---
+      
+      
+
+# a whole chapter file is stable
+
+    Code
+      print_file(path, "1_Bakgrunn.qmd")
+    Output
+      == 1_Bakgrunn.qmd ==
+      ---
+      title: Bakgrunn
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 0.0
+      
+      ---
+      # Bakgrunn
+      ```{r}
+      #| label: 'Import data for 1_Bakgrunn'
+      data_1_Bakgrunn <- readRDS('1_Bakgrunn/data_1_Bakgrunn.rds')
+      ```
+      
+      ## Gender{#sec-Gender-3314e4}
+      
+      
+      ::: {#fig-x1-sex-cat-plot-html}
+      
+      ```{r, fig.height=fig_height_h_barchart(n_y=1, n_cats_y=2, max_chars_labels_y=6, max_chars_cats_y=7)}
+      x1_sex_cat_plot_html <- 
+      	data_1_Bakgrunn |>
+      		makeme(dep = c(x1_sex), 
+      		type = 'cat_plot_html')
+      nrange <- stringi::stri_c('N = ', n_range2(x1_sex_cat_plot_html))
+      link <- make_link(data = x1_sex_cat_plot_html$data)
+      link_plot <- make_link(data = x1_sex_cat_plot_html, 
+      		file_suffix = '.png', link_prefix='[PNG](', 
+      		save_fn = ggsaver)
+      x <- I(paste0(c(nrange, link, link_plot), collapse=', '))
+      girafe(ggobj = x1_sex_cat_plot_html)
+      ```
+      
+      _Gender_. `{r} x`.
+      
+      :::
+      
+      
+      ::: {#tbl-x1-sex-cat-table-html}
+      
+      ```{r}
+      x1_sex_cat_table_html <- 
+      	data_1_Bakgrunn |>
+      		makeme(dep = c(x1_sex), 
+      		type = 'cat_table_html')
+      nrange <- stringi::stri_c('N = ', n_range(data = data_1_Bakgrunn, 
+      		dep = c(x1_sex)))
+      link <- make_link(data=x1_sex_cat_table_html)
+      x <- I(paste0(c(nrange, link), collapse=', '))
+      gt(x1_sex_cat_table_html)
+      ```
+      
+      _Gender_. N=`{r} x`.
+      
+      :::
+      
+      
+
+# chapter structure -- headings, anchors and float ids
+
+    Code
+      skeleton(path, "1_Trivsel.qmd")
+    Output
+      == 1_Trivsel.qmd ==
+      ---
+      title: Trivsel
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 0.0
+      
+      ---
+      # Trivsel
+      ## Do you consent to the following?{#sec-Do-you-consent-to-the-following-f0e1a9}
+      ::: {#fig-a-cat-plot-html}
+      ::: {#tbl-a-cat-table-html}
+      ### Gender{#sec-x1-sex-21446e}
+      ::: {#fig-a-x1-sex-cat-plot-html}
+      ::: {#tbl-a-x1-sex-cat-table-html}
+      ## How much do you like living in{#sec-How-much-do-you-like-living-in-962a6c}
+      ::: {#fig-b-1-cat-plot-html}
+      ::: {#tbl-b-1-cat-table-html}
+      ### Gender{#sec-x1-sex-3a2d01}
+      ::: {#fig-b-1-x1-sex-cat-plot-html}
+      ::: {#tbl-b-1-x1-sex-cat-table-html}
+      
+    Code
+      skeleton(path, "2_Bakgrunn.qmd")
+    Output
+      == 2_Bakgrunn.qmd ==
+      ---
+      title: Bakgrunn
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 1.0
+      
+      ---
+      # Bakgrunn
+      ## Gender{#sec-Gender-b4e6c9}
+      ::: {#fig-x1-sex-cat-plot-html}
+      ::: {#tbl-x1-sex-cat-table-html}
+      
+
+# variant 2 (tabset) output is stable -- univariate
+
+    Code
+      print_file(path, "1_Bakgrunn.qmd")
+    Output
+      == 1_Bakgrunn.qmd ==
+      ---
+      title: Bakgrunn
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 0.0
+      
+      ---
+      # Bakgrunn
+      ```{r}
+      #| label: 'Import data for 1_Bakgrunn'
+      data_1_Bakgrunn <- readRDS('1_Bakgrunn/data_1_Bakgrunn.rds')
+      ```
+      
+      ## Gender{#sec-Gender-3314e4}
+      
+      
+      ::: {#fig-x1-sex-cat-plot-html}
+      
+      ```{r}
+      #| output: asis
+      #| panel: tabset
+      plots <- 
+      	saros::makeme(data = data_1_Bakgrunn, 
+      		dep = c(x1_sex), 
+      		type='cat_plot_html', 
+      		crowd=c('target', 'others'), 
+      		mesos_var = params$mesos_var, 
+      		mesos_group = params$mesos_group)
+      
+      if(!all(vapply(plots, is.null, logical(1)))) {
+      
+        lapply(names(plots), function(.x) {
+          knitr::knit_child(text = c(
+            '',
+            '',
+            '##### `r .x`',
+            '',
+            '',
+            '```{r}',
+            'library(saros)',
+            'knitr::opts_template$set(fig = list(fig.height = fig_height_h_barchart2(plots[[.x]])))',
+            '',
+            '```',
+            '',
+            '```{r, opts.label=\'fig\'}',
+            'library(ggplot2)',
+            'library(ggiraph)',
+            'nrange <- stringi::stri_c(\'N = \', n_range2(plots[[.x]]))',
+            'link <- make_link(data = plots[[.x]]$data)',
+            'link_plot <- make_link(data = plots[[.x]], link_prefix=\'[PNG](\', file_suffix = \'.png\', save_fn = ggsaver)',
+            'x <- I(paste0(c(nrange, link, link_plot), collapse=\', \'))',
+            'girafe(ggobj = plots[[.x]])',
+            '```',
+            '',
+            '`r x`'
+            ), envir = environment(), quiet = TRUE)
+        }) |> unlist() |> cat(sep = '\n')
+      }
+      ```
+      
+      _Gender_.
+      
+      :::
+      
+      
+      ::: {#tbl-x1-sex-cat-table-html}
+      
+      ```{r}
+      #| output: asis
+      #| panel: tabset
+      tbls <- 
+      	saros::makeme(data = data_1_Bakgrunn, 
+      		dep = c(x1_sex), 
+      		type='cat_table_html', 
+      		crowd=c('target', 'others'), 
+      		mesos_var = params$mesos_var, 
+      		mesos_group = params$mesos_group)
+      if(!all(vapply(tbls, is.null, logical(1)))) {
+      
+      lapply(names(tbls), function(.x) {
+        knitr::knit_child(text = c(
+            '',
+            '',
+          '##### `r .x`',
+          '',
+          '```{r}',
+          'library(gt)',
+          'library(saros)',
+          'nrange <- stringi::stri_c(\'N = \', n_range(data = data_1_Bakgrunn, 
+      		dep = c(x1_sex)))',
+          'link <- make_link(data = tbls[[.x]])',
+          'x <- I(paste0(c(nrange, link), collapse=\', \')',
+          'gt(tbls[[.x]])',
+          '```',
+          '',
+          '`r x`',
+          ''
+          ), envir = environment(), quiet = TRUE)
+      }) |> unlist() |> cat(sep = '\n')
+      }
+      ```
+      
+      _Gender_.
+      
+      :::
+      
+      
+
+# variant 2 (tabset) output is stable -- bivariate
+
+    Code
+      skeleton(path, "1_Trivsel.qmd")
+    Output
+      == 1_Trivsel.qmd ==
+      ---
+      title: Trivsel
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 0.0
+      
+      ---
+      # Trivsel
+      ## Do you consent to the following?{#sec-Do-you-consent-to-the-following-f0e1a9}
+      ::: {#fig-a-cat-plot-html}
+      ::: {#tbl-a-cat-table-html}
+      ### Gender{#sec-x1-sex-21446e}
+      ::: {#fig-a-x1-sex-cat-plot-html}
+      ::: {#tbl-a-x1-sex-cat-table-html}
+      ## How much do you like living in{#sec-How-much-do-you-like-living-in-962a6c}
+      ::: {#fig-b-1-cat-plot-html}
+      ::: {#tbl-b-1-cat-table-html}
+      ### Gender{#sec-x1-sex-3a2d01}
+      ::: {#fig-b-1-x1-sex-cat-plot-html}
+      ::: {#tbl-b-1-x1-sex-cat-table-html}
+      
+    Code
+      skeleton(path, "2_Bakgrunn.qmd")
+    Output
+      == 2_Bakgrunn.qmd ==
+      ---
+      title: Bakgrunn
+      format: html
+      echo: false
+      fig-dpi: 800.0
+      number-offset: 1.0
+      
+      ---
+      # Bakgrunn
+      ## Gender{#sec-Gender-b4e6c9}
+      ::: {#fig-x1-sex-cat-plot-html}
+      ::: {#tbl-x1-sex-cat-table-html}
+      
+
+# headings are whitespace-normalised with a bare separator
+
+    Code
+      cat(headings, sep = "\n")
+    Output
+      # Trivsel
+      ## Do you consent to the following?{#sec-Do-you-consent-to-the-following-f0e1a9}
+      ### Agreement #1{#sec-Agreement-1-713dfd}
+      #### Gender{#sec-x1-sex-0cf217}
+      ### Agreement #2{#sec-Agreement-2-3bee20}
+      #### Gender{#sec-x1-sex-42cd8b}
+      ## How much do you like living in{#sec-How-much-do-you-like-living-in-962a6c}
+      ### Bejing{#sec-Bejing-211e6f}
+      #### Gender{#sec-x1-sex-19c095}
+      # Bakgrunn
+      ## Gender{#sec-Gender-b4e6c9}
+      ### Gender{#sec-Gender-740b46}
+

--- a/tests/testthat/test-qmd_snapshots.R
+++ b/tests/testthat/test-qmd_snapshots.R
@@ -71,12 +71,27 @@ print_file <- function(path, file) {
 # the chunk bodies. Compact enough to review on a richer report.
 skeleton <- function(path, file) {
   lines <- readLines(fs::path(path, file), warn = FALSE)
-  yaml_end <- if (length(lines) && lines[1] == "---") which(lines == "---")[2] else 0L
+  cat("== ", file, " ==\n", sep = "")
+
+  # An opening fence with no closing one is a regression this file exists to
+  # catch -- process_yaml() takes an `add_fences` argument, so it is reachable.
+  # Report it in the snapshot rather than dying: which(...)[2] is NA there, and
+  # seq_len(NA) errors with "argument must be coercible to non-negative
+  # integer", which says nothing about the file that caused it.
+  fences <- which(lines == "---")
+  yaml_end <- 0L
+  if (length(lines) && lines[1] == "---") {
+    if (length(fences) >= 2) {
+      yaml_end <- fences[2]
+    } else {
+      cat("<<< unterminated YAML front matter >>>\n")
+    }
+  }
+
   keep <- c(
     seq_len(yaml_end),
     grep("^#{1,6} |^::: \\{#|^:::: \\{\\.panel-tabset", lines)
   )
-  cat("== ", file, " ==\n", sep = "")
   writeLines(lines[sort(unique(keep))])
   cat("\n")
 }
@@ -117,8 +132,8 @@ testthat::test_that("index.qmd and report.qmd carry the report title", {
 })
 
 testthat::test_that("a whole chapter file is stable", {
-  # Full text, deliberately: this is the one place chunk bodies are pinned, so
-  # a stray character inside a template shows up here (#214).
+  # Full text, deliberately: this is the one place chunk bodies are pinned for
+  # the default templates, so a stray character inside one shows up here.
   path <- draft_into(one_chapter_overview, title = "Eksempelrapport")
   testthat::expect_snapshot(print_file(path, "1_Bakgrunn.qmd"))
 })
@@ -206,4 +221,28 @@ testthat::test_that("headings are whitespace-normalised with a bare separator", 
   # Stated as a property too, so the intent survives a careless snapshot accept.
   testthat::expect_false(any(grepl("^#{1,6}  ", headings)))
   testthat::expect_false(any(grepl("[ \t]$", headings)))
+})
+
+testthat::test_that("skeleton() reports unterminated YAML instead of erroring", {
+  # Guards the helper itself. Before this, an opening fence with no closing one
+  # made which(lines == "---")[2] NA and seq_len(NA) abort with "argument must
+  # be coercible to non-negative integer" -- an error that names neither the
+  # file nor the problem, in the one place a YAML regression would show up.
+  dir <- withr::local_tempdir()
+
+  writeLines(c("---", "title: x", "# Heading"), fs::path(dir, "unterminated.qmd"))
+  output <- utils::capture.output(skeleton(dir, "unterminated.qmd"))
+  testthat::expect_true(any(grepl("unterminated YAML front matter", output)))
+  testthat::expect_true(any(grepl("^# Heading$", output)))
+
+  # A well-formed file is unaffected: front matter through the closing fence,
+  # then the headings.
+  writeLines(
+    c("---", "title: x", "---", "# Heading", "body text"),
+    fs::path(dir, "wellformed.qmd")
+  )
+  output <- utils::capture.output(skeleton(dir, "wellformed.qmd"))
+  testthat::expect_false(any(grepl("unterminated", output)))
+  testthat::expect_true(any(grepl("^title: x$", output)))
+  testthat::expect_false(any(grepl("^body text$", output)))
 })

--- a/tests/testthat/test-qmd_snapshots.R
+++ b/tests/testthat/test-qmd_snapshots.R
@@ -1,0 +1,209 @@
+# Snapshots of the .qmd text draft_report() actually writes.
+#
+# The generated files are this package's deliverable, and until now nothing
+# asserted anything about their content -- test-draft_report.R checks file
+# counts and file *sizes* (`expect_lt(file.size(f), 3600)`). That is why this
+# class of bug kept reaching users:
+#
+#   #207  two first-level headings in every chapter file
+#   #208, #184  no `title` in the YAML front matter
+#   #216  unnormalised whitespace in section headings
+#
+# Each is a defect in emitted text that a byte-level snapshot catches for free
+# and a size assertion cannot see at all. Each was confirmed by re-introducing
+# it and watching the relevant test below fail.
+#
+# #214 (a stray `ewpage` above every tabset) is NOT guarded here, despite being
+# the same family of bug. Its guard is test-chunk_templates.R, which scans the
+# template store itself. That is the stronger place for it: a snapshot only
+# sees the templates a given example report happens to instantiate, so whether
+# it catches the bug depends on whether the fixture has an `indep`. The
+# source-level scan covers every template in every variant unconditionally.
+# Verified: re-introducing #214 fails test-chunk_templates.R and leaves these
+# snapshots green.
+#
+# These are only safe because #213 made the output deterministic -- anchors
+# used to carry two RNG-drawn digits. test-anchor_determinism.R pins that
+# property separately; if it ever regresses, these snapshots go flaky and that
+# test says why.
+#
+# When a snapshot changes, read the diff before accepting it: it is the exact
+# text your users will render.
+
+# Helpers ---------------------------------------------------------------------
+
+draft_into <- function(overview, envir = parent.frame(),
+                       label_separator = " - ", chunk_templates = NULL,
+                       organize_by = NULL, ...) {
+  path <- withr::local_tempdir(.local_envir = envir)
+  refine_args <- list(
+    chapter_overview = overview,
+    data = saros.base::ex_survey,
+    label_separator = label_separator,
+    chunk_templates = chunk_templates,
+    progress = FALSE
+  )
+  if (!is.null(organize_by)) refine_args$organize_by <- organize_by
+  chapter_structure <- suppressMessages(suppressWarnings(
+    do.call(saros.base::refine_chapter_overview, refine_args)
+  ))
+  suppressMessages(saros.base::draft_report(
+    data = saros.base::ex_survey,
+    chapter_structure = chapter_structure,
+    path = path,
+    ...
+  ))
+  path
+}
+
+# Relative paths only -- an absolute tempdir would change on every run.
+relative_files <- function(path, glob = "*") {
+  sort(fs::path_rel(fs::dir_ls(path, recurse = TRUE, type = "file", glob = glob), start = path))
+}
+
+print_file <- function(path, file) {
+  cat("== ", file, " ==\n", sep = "")
+  writeLines(readLines(fs::path(path, file), warn = FALSE))
+  cat("\n")
+}
+
+# YAML front matter, headings and float ids: the structural skeleton, without
+# the chunk bodies. Compact enough to review on a richer report.
+skeleton <- function(path, file) {
+  lines <- readLines(fs::path(path, file), warn = FALSE)
+  yaml_end <- if (length(lines) && lines[1] == "---") which(lines == "---")[2] else 0L
+  keep <- c(
+    seq_len(yaml_end),
+    grep("^#{1,6} |^::: \\{#|^:::: \\{\\.panel-tabset", lines)
+  )
+  cat("== ", file, " ==\n", sep = "")
+  writeLines(lines[sort(unique(keep))])
+  cat("\n")
+}
+
+# A battery of two items plus a bivariate, and a single item in its own
+# chapter -- enough to exercise prefix headings, indep headings and the
+# chapter heading itself.
+two_chapter_overview <- data.frame(
+  chapter = c("Trivsel", "Trivsel", "Bakgrunn"),
+  dep = c("a_1, a_2", "b_1", "x1_sex"),
+  indep = c("x1_sex", "", "")
+)
+
+# The smallest thing that still produces a whole chapter.
+one_chapter_overview <- data.frame(
+  chapter = "Bakgrunn",
+  dep = "x1_sex",
+  indep = ""
+)
+
+# Tests -----------------------------------------------------------------------
+
+testthat::test_that("the set of generated files is stable", {
+  path <- draft_into(two_chapter_overview, title = "Eksempelrapport",
+                     report_filename = "report")
+  testthat::expect_snapshot(cat(relative_files(path), sep = "\n"))
+})
+
+testthat::test_that("index.qmd and report.qmd carry the report title", {
+  # Guards #208 and #184: process_yaml() only assigned `title` when an explicit
+  # yaml_file was supplied, so both files were written without one.
+  path <- draft_into(two_chapter_overview, title = "Eksempelrapport",
+                     report_filename = "report")
+  testthat::expect_snapshot({
+    print_file(path, "index.qmd")
+    print_file(path, "report.qmd")
+  })
+})
+
+testthat::test_that("a whole chapter file is stable", {
+  # Full text, deliberately: this is the one place chunk bodies are pinned, so
+  # a stray character inside a template shows up here (#214).
+  path <- draft_into(one_chapter_overview, title = "Eksempelrapport")
+  testthat::expect_snapshot(print_file(path, "1_Bakgrunn.qmd"))
+})
+
+testthat::test_that("chapter structure -- headings, anchors and float ids", {
+  # Guards #207 (one `#` heading per file, not two), #213 (anchors are a hash
+  # of the heading's position, not RNG digits) and the heading text itself.
+  path <- draft_into(two_chapter_overview, title = "Eksempelrapport")
+  testthat::expect_snapshot({
+    skeleton(path, "1_Trivsel.qmd")
+    skeleton(path, "2_Bakgrunn.qmd")
+  })
+})
+
+testthat::test_that("variant 2 (tabset) output is stable -- univariate", {
+  # A general regression net for the tabset templates, not a guard for #214;
+  # see the note at the top of this file.
+  path <- draft_into(
+    one_chapter_overview,
+    title = "Eksempelrapport",
+    chunk_templates = saros.base::get_chunk_template_defaults(2)
+  )
+  testthat::expect_snapshot(print_file(path, "1_Bakgrunn.qmd"))
+})
+
+testthat::test_that("variant 2 (tabset) output is stable -- bivariate", {
+  # The univariate fixture above never instantiates the templates that declare
+  # a `.template_variable_type_indep`, which is most of variant 2. Skeleton
+  # form, since the point here is coverage of more templates rather than their
+  # chunk bodies.
+  path <- draft_into(
+    two_chapter_overview,
+    title = "Eksempelrapport",
+    chunk_templates = saros.base::get_chunk_template_defaults(2)
+  )
+  testthat::expect_snapshot({
+    skeleton(path, "1_Trivsel.qmd")
+    skeleton(path, "2_Bakgrunn.qmd")
+  })
+
+  # Cheap backstop across every generated file. The primary guard for this
+  # corruption is test-chunk_templates.R, which checks the templates directly.
+  content <- unlist(lapply(
+    fs::dir_ls(path, type = "file", glob = "*.qmd"),
+    readLines, warn = FALSE
+  ), use.names = FALSE)
+  testthat::expect_false(any(grepl("ewpage", content, fixed = TRUE)))
+  testthat::expect_false(any(grepl("newpage", content, fixed = TRUE)))
+})
+
+testthat::test_that("headings are whitespace-normalised with a bare separator", {
+  # Guards #216: `.variable_label_suffix` was never passed to trim_columns(),
+  # so suffixes kept leading/trailing spaces and internal runs of them. These
+  # become section headings, where leading whitespace is significant in
+  # Markdown.
+  #
+  # Two conditions are both required, and getting either wrong makes this test
+  # pass against the broken code:
+  #
+  # 1. The separator must carry no spaces of its own. Labels in ex_survey read
+  #    "Do you consent to the following? - Agreement #1", so splitting on "-"
+  #    rather than " - " leaves a trailing space on the prefix and a leading one
+  #    on the suffix. With ":" nothing splits at all and the suffix is empty.
+  #
+  # 2. `organize_by` must include `.variable_label_suffix_dep`, or the suffix
+  #    never becomes a heading and the bug has nowhere to show. The default
+  #    groups on the *prefix*, which was passed to trim_columns() twice -- so
+  #    the prefix was always normalised, both before and after the fix.
+  path <- draft_into(
+    two_chapter_overview,
+    label_separator = "-",
+    organize_by = c(
+      ".chapter_number", ".variable_label_prefix_dep",
+      ".variable_label_suffix_dep", ".variable_name_indep", ".template_name"
+    )
+  )
+
+  headings <- unlist(lapply(
+    fs::dir_ls(path, type = "file", glob = "*.qmd"),
+    function(file) grep("^#{1,6} ", readLines(file, warn = FALSE), value = TRUE)
+  ), use.names = FALSE)
+
+  testthat::expect_snapshot(cat(headings, sep = "\n"))
+
+  # Stated as a property too, so the intent survives a careless snapshot accept.
+  testthat::expect_false(any(grepl("^#{1,6}  ", headings)))
+  testthat::expect_false(any(grepl("[ \t]$", headings)))
+})


### PR DESCRIPTION
The `.qmd` files `draft_report()` writes are this package's deliverable, and nothing asserted anything about their content. `test-draft_report.R` checks file counts and file *sizes*:

```r
testthat::expect_lt(file.size(output_files[1]), 3600)
testthat::expect_gt(file.size(output_files[3]), 3350)
```

A size band cannot see a missing YAML `title`, a duplicated heading, or a leading space. That is how three bugs fixed earlier in this cycle reached users in the first place.

## Verified, not assumed

Every bug this claims to guard was re-introduced and the tests confirmed to fail:

| Bug | Break applied | Failures |
|---|---|---|
| **#207** two H1s per chapter | `.chapter_number` dropped from `ignore_heading_for_group` | 5 |
| **#208 / #184** no YAML title | `title` dropped from the default `process_yaml()` branch | 5 |
| **#216** heading whitespace | suffix not passed to `trim_columns()` | 2 |

Baseline clean, working tree restored after each.

## What is deliberately *not* here

**#214** (the stray `ewpage` above every tabset) is the same family of bug, but its guard is `test-chunk_templates.R`, which scans the template store directly. That is the stronger place for it: a snapshot only sees the templates its fixture happens to instantiate, so whether it catches the bug depends on whether the fixture has an `indep`. The source-level scan covers every template in every variant unconditionally.

Confirmed both ways: re-introducing #214 fails `test-chunk_templates.R` (2 failures) and leaves these snapshots green. The file says so explicitly rather than implying coverage it does not have.

I did broaden variant-2 coverage anyway — a bivariate skeleton case plus an `ewpage`/`newpage` backstop across all generated files — as a regression net, not as the primary guard.

## Two traps that produced false-green tests

Both were caught by the break-test step; both would otherwise have shipped as tests that pass against broken code.

**#216 needs two conditions at once.** The separator must carry no spaces of its own — `ex_survey` labels read `"Do you consent to the following? - Agreement #1"`, so `"-"` splits and leaves whitespace on both sides, whereas `":"` never splits at all and the suffix is empty. *And* `organize_by` must include `.variable_label_suffix_dep`, or the suffix never becomes a heading. The default groups on the **prefix**, which the pre-fix code normalised anyway (it passed `.variable_label_prefix` to `trim_columns()` twice). My first two attempts each got one of these wrong and passed against the bug.

**Reproducing #214 needs a double backslash.** The original source (`3aec712`) read `'#\\newpage'`, which parses to a string holding one literal `\`. Injecting a single backslash is consumed at parse time and leaves `ewpage` with no backslash — a different corruption from the one that shipped, which is why it slipped past both test files and briefly looked like `test-chunk_templates.R` was vacuous. It is not.

## Shape

330 snapshot lines, layered to stay reviewable:

- **Full text** for minimal fixtures — the only place chunk bodies are pinned.
- **Skeletons** (YAML front matter, headings, float ids) for richer fixtures — coverage of more templates without the bulk.
- Plain property assertions alongside two snapshots (no `ewpage`, no leading/trailing whitespace in headings), so the intent survives someone accepting a snapshot diff carelessly.

Only possible now that #213 made the output deterministic — anchors used to carry two RNG-drawn digits. `test-anchor_determinism.R` pins that separately, so if it regresses these go flaky and that test explains why.

Suite: **848 passing**, up from 835.

## Reviewing this

When a snapshot changes, read the diff before accepting it — it is the exact text users will render.
